### PR TITLE
Optimize stream copies and CRC hashing

### DIFF
--- a/Overstrike/Detectors/ModsDetection.cs
+++ b/Overstrike/Detectors/ModsDetection.cs
@@ -1,9 +1,8 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
 
-using Ionic.Crc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Overstrike.Data;
@@ -87,7 +86,7 @@ namespace Overstrike.Detectors {
 					if (entry.Key.EndsWith("." + extension, StringComparison.OrdinalIgnoreCase)) {
 						using var file = new MemoryStream();
 						using (var entryStream = entry.OpenEntryStream()) {
-							entryStream.CopyTo(file);
+							entryStream.CopyTo(file, 1024 * 1024);
 						}
 						file.Seek(0, SeekOrigin.Begin);
 
@@ -337,6 +336,7 @@ namespace Overstrike.Detectors {
 			public List<ModEntry> ProducedEntries;
 
 			private const int FIRST_PIECE_LENGTH = 4096;
+			private const int READ_BUFFER_SIZE = 1024 * 1024;
 
 			public static uint CalculateChecksum1(FileStream stream) {
 				long len = stream.Length;
@@ -349,18 +349,20 @@ namespace Overstrike.Detectors {
 				stream.Position = 0;
 				stream.Read(buffer);
 				stream.Position = oldPosition;
-				return Crc32.Compute(buffer);
+				return BitConverter.ToUInt32(System.IO.Hashing.Crc32.Hash(buffer));
 			}
 
 			public static int CalculateChecksum2(FileStream stream) {
 				var oldPosition = stream.Position;
 				stream.Position = 0;
-
-				var c = new CRC32();
-				var r = c.GetCrc32(stream);
-
+				var crc = new System.IO.Hashing.Crc32();
+				byte[] buffer = new byte[READ_BUFFER_SIZE];
+				int bytesRead;
+				while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) > 0) {
+					crc.Append(buffer.AsSpan(0, bytesRead));
+				}
 				stream.Position = oldPosition;
-				return r;
+				return (int)BitConverter.ToUInt32(crc.GetCurrentHash());
 			}
 		}
 	}

--- a/Overstrike/Detectors/ModsDetection.cs
+++ b/Overstrike/Detectors/ModsDetection.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/InstallerBase.cs
+++ b/Overstrike/Installers/InstallerBase.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/InstallerBase.cs
+++ b/Overstrike/Installers/InstallerBase.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -70,7 +70,7 @@ namespace Overstrike.Installers {
 
 		protected void OverwriteAsset(byte span, ulong assetId, uint archiveIndex, BinaryWriter archiveWriter, Stream data) {
 			long archiveOffset = archiveWriter.BaseStream.Position;
-			data.CopyTo(archiveWriter.BaseStream);
+			data.CopyTo(archiveWriter.BaseStream, 1024 * 1024);
 			long fileSize = archiveWriter.BaseStream.Position - archiveOffset;
 
 			AddOrUpdateAssetEntry(span, assetId, archiveIndex, (uint)archiveOffset, (uint)fileSize);
@@ -93,7 +93,7 @@ namespace Overstrike.Installers {
 			if (withHeader) data.Read(header, 0, 36);
 
 			long archiveOffset = archiveWriter.BaseStream.Position;
-			data.CopyTo(archiveWriter.BaseStream);
+			data.CopyTo(archiveWriter.BaseStream, 1024 * 1024);
 			long fileSize = archiveWriter.BaseStream.Position - archiveOffset;
 
 			int assetIndex = _toc.FindOrAddAsset(span, assetId);

--- a/Overstrike/Installers/MMSuit1Installer.cs
+++ b/Overstrike/Installers/MMSuit1Installer.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -98,10 +98,10 @@ namespace Overstrike.Installers {
 			var suitArchiveIndex = GetArchiveIndex("Suits\\" + id);
 			var assets = GetEntryByFullName(zip, id + "/" + id);
 
-			using (var f = new FileStream(suitArchivePath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+			using (var f = new FileStream(suitArchivePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024)) {
 				using (var w = new BinaryWriter(f)) {
 					using (var stream = assets.Open()) {
-						stream.CopyTo(w.BaseStream);
+						stream.CopyTo(w.BaseStream, 1024 * 1024);
 					}
 				}
 			}

--- a/Overstrike/Installers/MMSuit1Installer.cs
+++ b/Overstrike/Installers/MMSuit1Installer.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/MMSuit2Installer.cs
+++ b/Overstrike/Installers/MMSuit2Installer.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -50,10 +50,10 @@ namespace Overstrike.Installers {
 			var suitArchiveIndex = GetArchiveIndex("Suits\\" + id);
 			var assets = GetEntryByFullName(zip, id + "/" + id);
 
-			using (var f = new FileStream(suitArchivePath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+			using (var f = new FileStream(suitArchivePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024)) {
 				using (var w = new BinaryWriter(f)) {
 					using (var stream = assets.Open()) {
-						stream.CopyTo(w.BaseStream);
+						stream.CopyTo(w.BaseStream, 1024 * 1024);
 					}
 				}
 			}

--- a/Overstrike/Installers/MMSuit2Installer.cs
+++ b/Overstrike/Installers/MMSuit2Installer.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/MSM2Suit2Installer.cs
+++ b/Overstrike/Installers/MSM2Suit2Installer.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -244,10 +244,10 @@ namespace Overstrike.Installers {
 			var archivePath = Path.GetRelativePath(_gamePath, modPath);
 			var archiveIndex = GetArchiveIndex(archivePath);
 			
-			using (var f = new FileStream(modPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+			using (var f = new FileStream(modPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024)) {
 				using var w = new BinaryWriter(f);
 				file.Position = 0;
-				file.CopyTo(w.BaseStream);
+				file.CopyTo(w.BaseStream, 1024 * 1024);
 			}
 
 			foreach (var asset in assets) {

--- a/Overstrike/Installers/MSM2Suit2Installer.cs
+++ b/Overstrike/Installers/MSM2Suit2Installer.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/MSM2SuitStyleInstaller.cs
+++ b/Overstrike/Installers/MSM2SuitStyleInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -220,10 +220,10 @@ namespace Overstrike.Installers {
 			var archivePath = Path.GetRelativePath(_gamePath, modPath);
 			var archiveIndex = GetArchiveIndex(archivePath);
 			
-			using (var f = new FileStream(modPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+			using (var f = new FileStream(modPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024)) {
 				using var w = new BinaryWriter(f);
 				file.Position = 0;
-				file.CopyTo(w.BaseStream);
+				file.CopyTo(w.BaseStream, 1024 * 1024);
 			}
 
 			foreach (var asset in assets) {

--- a/Overstrike/Installers/MSM2SuitStyleInstaller.cs
+++ b/Overstrike/Installers/MSM2SuitStyleInstaller.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/MSMRSuitInstaller.cs
+++ b/Overstrike/Installers/MSMRSuitInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -79,10 +79,10 @@ namespace Overstrike.Installers {
 			var suitArchiveIndex = GetArchiveIndex("Suits\\" + id);
 			var assets = GetEntryByFullName(zip, id + "/" + id);
 
-			using (var f = new FileStream(suitArchivePath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+			using (var f = new FileStream(suitArchivePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024)) {
 				using (var w = new BinaryWriter(f)) {
 					using (var stream = assets.Open()) {
-						stream.CopyTo(w.BaseStream);
+						stream.CopyTo(w.BaseStream, 1024 * 1024);
 					}
 				}
 			}

--- a/Overstrike/Installers/MSMRSuitInstaller.cs
+++ b/Overstrike/Installers/MSMRSuitInstaller.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/SMPCModInstaller.cs
+++ b/Overstrike/Installers/SMPCModInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -48,7 +48,7 @@ namespace Overstrike.Installers {
 
 			long archiveOffset = modArchiveFile.BaseStream.Position;
 			using (var stream = asset.Open()) {
-				stream.CopyTo(modArchiveFile.BaseStream);
+				stream.CopyTo(modArchiveFile.BaseStream, 1024 * 1024);
 			}
 			long fileSize = modArchiveFile.BaseStream.Position - archiveOffset;
 

--- a/Overstrike/Installers/SMPCModInstaller.cs
+++ b/Overstrike/Installers/SMPCModInstaller.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/ScriptInstaller.cs
+++ b/Overstrike/Installers/ScriptInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -335,9 +335,9 @@ namespace Overstrike.Installers {
 				var path = Path.Combine(scriptsPath, entry.FullName);
 				try { Directory.CreateDirectory(Path.GetDirectoryName(path)); } catch {}
 
-				using var f = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+				using var f = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024);
 				using var data = entry.Open();		
-				data.CopyTo(f);
+				data.CopyTo(f, 1024 * 1024);
 			}
 		}
 	}

--- a/Overstrike/Installers/ScriptInstaller.cs
+++ b/Overstrike/Installers/ScriptInstaller.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Installers/StageInstaller.cs
+++ b/Overstrike/Installers/StageInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -23,7 +23,7 @@ namespace Overstrike.Installers {
 		public void Work(string modPath, string relativeModPath) {
 			var newArchiveIndex = CreateArchive(relativeModPath);
 
-			using (var f = new FileStream(modPath, FileMode.Create, FileAccess.Write, FileShare.None)) {
+			using (var f = new FileStream(modPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 1024 * 1024)) {
 				using (var w = new BinaryWriter(f)) {
 					using (ZipArchive zip = ReadStageFile()) {
 						PrepWork(zip);

--- a/Overstrike/Installers/StageInstaller.cs
+++ b/Overstrike/Installers/StageInstaller.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.

--- a/Overstrike/Overstrike.csproj
+++ b/Overstrike/Overstrike.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>

--- a/Overstrike/Overstrike.csproj
+++ b/Overstrike/Overstrike.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -26,6 +26,7 @@
     <PackageReference Include="BCnEncoder.Net" Version="2.1.0" />
     <PackageReference Include="SharpCompress" Version="0.33.0" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
     <PackageReference Include="WindowsAPICodePack-Shell" Version="1.1.1" />
   </ItemGroup>
 

--- a/Overstrike/Utils/NestedFiles.cs
+++ b/Overstrike/Utils/NestedFiles.cs
@@ -1,4 +1,4 @@
-﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.
@@ -48,7 +48,7 @@ namespace Overstrike.Utils {
 				if (entry.Key.Equals(fullpath, StringComparison.OrdinalIgnoreCase)) {
 					var file = new MemoryStream();
 					using (var entryStream = entry.OpenEntryStream()) {
-						entryStream.CopyTo(file);
+						entryStream.CopyTo(file, 1024 * 1024);
 					}
 					file.Seek(0, SeekOrigin.Begin);
 
@@ -79,10 +79,9 @@ namespace Overstrike.Utils {
 		public static byte[] GetZippedFileBytes(ZipArchive zip, string filename) {
 			var zipEntry = GetZipEntryByFullName(zip, filename);
 			using var stream = zipEntry.Open();
-			var file = new MemoryStream();
-			stream.CopyTo(file);
-			file.Seek(0, SeekOrigin.Begin);
-			return file.ToArray();
+			var file = new MemoryStream(zipEntry.Length > 0 ? (int)zipEntry.Length : 4096);
+			stream.CopyTo(file, 1024 * 1024);
+			return file.GetBuffer().AsSpan(0, (int)file.Length).ToArray();
 		}
 	}
 }

--- a/Overstrike/Utils/NestedFiles.cs
+++ b/Overstrike/Utils/NestedFiles.cs
@@ -1,4 +1,4 @@
-// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
+﻿// Overstrike -- an open-source mod manager for PC ports of Insomniac Games' games.
 // This program is free software, and can be redistributed and/or modified by you. It is provided 'as-is', without any warranty.
 // For more details, terms and conditions, see GNU General Public License.
 // A copy of the that license should come with this program (LICENSE.txt). If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Replaced Ionic CRC usage with `System.IO.Hashing.Crc32` and added the corresponding package reference, removing the old CRC dependency path. Also standardized large-buffer stream copying (1 MB) across detectors/installers and improved zip extraction memory handling by pre-sizing `MemoryStream` and avoiding extra copies, which should reduce overhead for large mod/archive operations.

I don't have exact numbers for how much faster it is, but with lots of mods its pretty noticable